### PR TITLE
fix docker ip range

### DIFF
--- a/docker-setup.sh
+++ b/docker-setup.sh
@@ -9,7 +9,7 @@ function setup_conf_and_secret {
     postconf -e 'smtp_sasl_password_maps = hash:/etc/postfix/relay_passwd'
     postconf -e 'smtp_sasl_security_options = noanonymous'
     postconf -e 'smtp_tls_security_level = encrypt'
-    postconf -e 'mynetworks = 127.0.0.0/8 172.17.0.0/16 10.42.0.0/16'
+    postconf -e 'mynetworks = 127.0.0.0/8 172.16.0.0/12 10.42.0.0/16'
 
     echo "$MTP_RELAY   $MTP_USER:$MTP_PASS" > /etc/postfix/relay_passwd
     postmap /etc/postfix/relay_passwd


### PR DESCRIPTION
postfix config should consider all docker networks local. 
In fact, if no custom config is supplied the network is correctly set with a larger network mask to account for additional docker networks  but in the setup_conf_and_secret function the network wrongly uses /16 mask