### PR TITLE
Change to python 3.6 from regular repo

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,13 +9,10 @@ VOLUME ["/var/log", "/var/spool/postfix"]
 RUN rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7 && \
     yum updateinfo -y && \
     yum update -y glibc && \
-    yum install -y epel-release && \
-    rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-7 && \
-    yum install -y python34-devel postfix cyrus-sasl cyrus-sasl-plain mailx && \
+    yum install -y python3 postfix cyrus-sasl cyrus-sasl-plain mailx && \
     yum clean all
 
-RUN curl https://bootstrap.pypa.io/get-pip.py | python3.4 && \
-    pip3 install chaperone
+RUN python3 -m pip install chaperone
 
 RUN mkdir -p /etc/chaperone.d
 COPY chaperone.conf /etc/chaperone.d/chaperone.conf
@@ -23,4 +20,4 @@ COPY chaperone.conf /etc/chaperone.d/chaperone.conf
 COPY docker-setup.sh /docker-setup.sh
 RUN chmod +x /docker-setup.sh
 
-ENTRYPOINT ["/usr/bin/chaperone"]
+ENTRYPOINT ["/usr/local/bin/chaperone"]


### PR DESCRIPTION
This PR removes the need for EPEL and switches to use Python 3.6 from regular repos.
